### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ El formato se basa en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/
 
 - Añade personalización de CORS por variables de entorno.
 
+### 🐞 Arreglado
+
+- Enviar el último turno al cambiar el estado de un turno en el _endpoint_ API-Key `consultar_configuracion_usuario`.
+
 
 ## [1.3.0] - 2026-06-09
 

--- a/tauro/blueprints/api_key_v1/endpoints/consultar_configuracion_usuario.py
+++ b/tauro/blueprints/api_key_v1/endpoints/consultar_configuracion_usuario.py
@@ -60,11 +60,17 @@ class ConsultarConfiguracionUsuario(Resource):
                 for utt in usuarios_turnos_tipos
             ]
 
-        # Consultar el último turno en "EN ESPERA" o "PASE A VENTANILLA" del usuario
+        # Consultar el último turno en "EN ESPERA" o "PASE A VENTANILLA" o "ATENDIENDO" del usuario
         turnos = (
             Turno.query.join(TurnoEstado)
             .join(TurnoTipo)
-            .filter(or_(TurnoEstado.nombre == "EN ESPERA", TurnoEstado.nombre == "PASE A VENTANILLA"))
+            .filter(
+                or_(
+                    TurnoEstado.nombre == "EN ESPERA",
+                    TurnoEstado.nombre == "PASE A VENTANILLA",
+                    TurnoEstado.nombre == "ATENDIENDO",
+                )
+            )
             .filter(Turno.usuario_id == usuario.id)
             .filter(Turno.estatus == "A")
             .order_by(Turno.id.desc())


### PR DESCRIPTION
### 🐞 Arreglado

- Enviar el último turno al cambiar el estado de un turno en el _endpoint_ API-Key `consultar_configuracion_usuario`.