### PR TITLE
Quitar del voceador

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,17 @@
 Todos los cambios notables en este proyecto serán documentados en este archivo.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/).
 
-## [1.4.0] - 2026-06-11
+## [1.4.0] - 2026-06-12
 
 ### ✨ Mejoras
 
-- Añade vocear cuando el estado del turno es pasar a un cubículo.
+- Añade vocear cuando el estado del turno es pasar a un cubículo. "PASE A VENTANILLA", "ATENDIENDO EN CUBICULO".
 - Añade personalización de CORS por variables de entorno.
 
 ### 🐞 Arreglado
 
 - Enviar el último turno al cambiar el estado de un turno en el _endpoint_ API-Key `consultar_configuracion_usuario`.
+- Quitar del voceador cuando se cambien a ciertos estados el turno. "ATENDIENDO", "EN ESPERA DE CUBICULO", "CANCELADO", "COMPLETADO".
 
 
 ## [1.3.0] - 2026-06-09

--- a/tauro/blueprints/api_key_v1/endpoints/actualizar_turno_estado.py
+++ b/tauro/blueprints/api_key_v1/endpoints/actualizar_turno_estado.py
@@ -139,10 +139,17 @@ class ActualizarTurnoEstado(Resource):
         socketio.send(one_turno_out)
 
         # Vocear el turno
-        if turno.turno_estado.nombre in ["PASE A VENTANILLA", "ATENDIENDO", "CANCELADO", "ATENDIENDO EN CUBICULO"]:
+        if turno.turno_estado.nombre in ["PASE A VENTANILLA", "ATENDIENDO EN CUBICULO"]:
             voceador_turnos = VocearTurnos()
             try:
                 resultado, mensaje_resp = voceador_turnos.agregar_mensaje(turno)
+            except Exception as e:
+                pass
+        # Quitar del voceador
+        elif turno.turno_estado.nombre in ["ATENDIENDO", "EN ESPERA DE CUBICULO", "CANCELADO", "COMPLETADO"]:
+            voceador_turnos = VocearTurnos()
+            try:
+                resultado, mensaje_resp = voceador_turnos.quitar_mensaje(turno)
             except Exception as e:
                 pass
 

--- a/tauro/blueprints/api_oauth2_v1/endpoints/actualizar_turno_estado.py
+++ b/tauro/blueprints/api_oauth2_v1/endpoints/actualizar_turno_estado.py
@@ -137,11 +137,18 @@ class ActualizarTurnoEstado(Resource):
         # Enviar mensaje vía socketio
         socketio.send(one_turno_out)
 
-        # Vocear el turno
-        if turno.turno_estado.nombre in ["PASE A VENTANILLA", "ATENDIENDO", "CANCELADO", "ATENDIENDO EN CUBICULO"]:
+        # Añadir al voceador el turno
+        if turno.turno_estado.nombre in ["PASE A VENTANILLA", "ATENDIENDO EN CUBICULO"]:
             voceador_turnos = VocearTurnos()
             try:
                 resultado, mensaje_resp = voceador_turnos.agregar_mensaje(turno)
+            except Exception as e:
+                pass
+        # Quitar del voceador
+        elif turno.turno_estado.nombre in ["ATENDIENDO", "EN ESPERA DE CUBICULO", "CANCELADO", "COMPLETADO"]:
+            voceador_turnos = VocearTurnos()
+            try:
+                resultado, mensaje_resp = voceador_turnos.quitar_mensaje(turno)
             except Exception as e:
                 pass
 


### PR DESCRIPTION
- Quitar del voceador cuando se cambien a ciertos estados el turno. "ATENDIENDO", "EN ESPERA DE CUBICULO", "CANCELADO", "COMPLETADO".