### PR TITLE
Unidad pronunciacion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ El formato se basa en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/
 
 ### ✨ Mejoras
 
+- Las unidades ahora incluyen un campo nuevo para indicar cómo pronunciarlo.
 - Nuevo estado de turno añadido: `ATENDIENDO EN CUBICULO`.
 - Añade vocear cuando el estado del turno es pasar a un cubículo. "PASE A VENTANILLA", "ATENDIENDO EN CUBICULO".
 - Añade personalización de CORS por variables de entorno.
@@ -24,6 +25,8 @@ El formato se basa en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/
 
 ### ⚙️ Requerimiento
 
+- Ejecutar SQL:
+  - Añadir campo nuevo `pronunciacion` a la tabla `unidades`: `v1.3.0-01-add-campo-unidades.sql`.
 - Añadir nuevos tipos de estado turnos: `PASE A UBICACION` = 7, `PASE A CUBICULO` = 8.
 
 

--- a/tauro/blueprints/unidades/forms.py
+++ b/tauro/blueprints/unidades/forms.py
@@ -12,5 +12,6 @@ class UnidadForm(FlaskForm):
 
     clave = StringField("Clave", validators=[DataRequired(), Length(max=16)])
     nombre = StringField("Nombre", validators=[DataRequired(), Length(max=256)])
+    pronunciacion = StringField("Pronunciación", validators=[Optional(), Length(max=32)])
     es_activo = BooleanField("Activo", validators=[Optional()])
     guardar = SubmitField("Guardar")

--- a/tauro/blueprints/unidades/models.py
+++ b/tauro/blueprints/unidades/models.py
@@ -2,7 +2,7 @@
 Unidades, modelos
 """
 
-from typing import List
+from typing import List, Optional
 
 from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -23,6 +23,7 @@ class Unidad(database.Model, UniversalMixin):
     # Columnas
     clave: Mapped[str] = mapped_column(String(16), unique=True)
     nombre: Mapped[str] = mapped_column(String(256))
+    pronunciacion: Mapped[Optional[str]] = mapped_column(String(32))
     es_activo: Mapped[bool] = mapped_column(default=True)
 
     # Hijos

--- a/tauro/blueprints/unidades/templates/unidades/detail.jinja2
+++ b/tauro/blueprints/unidades/templates/unidades/detail.jinja2
@@ -23,6 +23,7 @@
     {% call detail.card(estatus=unidad.estatus) %}
         {{ detail.label_value_big('Clave', unidad.clave) }}
         {{ detail.label_value('Nombre', unidad.nombre) }}
+        {{ detail.label_value('Pronunciación', unidad.pronunciacion) }}
         {{ detail.label_value_boolean('Activo', unidad.es_activo) }}
     {% endcall %}
     {# Listado de Usuarios #}

--- a/tauro/blueprints/unidades/templates/unidades/edit.jinja2
+++ b/tauro/blueprints/unidades/templates/unidades/edit.jinja2
@@ -14,6 +14,8 @@
         {% call f.form_tag('unidades.edit', fid='unidad_form', **form_kwargs) %}
             {% call f.form_group(form.clave) %}{% endcall %}
             {% call f.form_group(form.nombre) %}{% endcall %}
+            {% call f.form_group(form.pronunciacion) %}{% endcall %}
+            <small>Utilice puntos para deletrear las palabras</small>
             {% call f.form_group(form.es_activo) %}{% endcall %}
             {% call f.form_group(form.guardar) %}{% endcall %}
         {% endcall %}

--- a/tauro/blueprints/unidades/templates/unidades/new.jinja2
+++ b/tauro/blueprints/unidades/templates/unidades/new.jinja2
@@ -13,6 +13,7 @@
         {% call f.form_tag('unidades.new', fid='unidad_form') %}
             {% call f.form_group(form.clave) %}{% endcall %}
             {% call f.form_group(form.nombre) %}{% endcall %}
+            {% call f.form_group(form.pronunciacion) %}{% endcall %}
             {% call f.form_group(form.es_activo) %}{% endcall %}
             {% call f.form_group(form.guardar) %}{% endcall %}
         {% endcall %}

--- a/tauro/blueprints/unidades/views.py
+++ b/tauro/blueprints/unidades/views.py
@@ -116,6 +116,7 @@ def new():
         unidad = Unidad(
             clave=safe_clave(form.clave.data),
             nombre=safe_string(form.nombre.data),
+            pronunciacion=safe_message(form.pronunciacion.data, default_output_str=None),
             es_activo=form.es_activo.data,
         )
         unidad.save()
@@ -128,6 +129,7 @@ def new():
         bitacora.save()
         flash(bitacora.descripcion, "success")
         return redirect(bitacora.url)
+    form.es_activo.data = True
     return render_template("unidades/new.jinja2", form=form)
 
 
@@ -150,6 +152,7 @@ def edit(unidad_id):
         if es_valido:
             unidad.clave = safe_clave(form.clave.data)
             unidad.nombre = safe_string(form.nombre.data)
+            unidad.pronunciacion = safe_message(form.pronunciacion.data, default_output_str=None)
             unidad.es_activo = form.es_activo.data
             unidad.save()
             bitacora = Bitacora(
@@ -163,6 +166,7 @@ def edit(unidad_id):
             return redirect(bitacora.url)
     form.clave.data = unidad.clave
     form.nombre.data = unidad.nombre
+    form.pronunciacion.data = unidad.pronunciacion
     form.es_activo.data = unidad.es_activo
     return render_template("unidades/edit.jinja2", form=form, unidad=unidad)
 

--- a/tauro/services/vocear_turnos.py
+++ b/tauro/services/vocear_turnos.py
@@ -114,7 +114,10 @@ class VocearTurnos:
     def contruir_mensaje_turno(self, turno: Turno, unidad: Unidad) -> Mensaje:
         """Construye el mensaje para cada turno que pasen a una ubicación"""
 
-        unidad_clave_deletreada = ".".join(unidad.clave)
+        if unidad.pronunciacion:
+            unidad_clave_deletreada = unidad.pronunciacion
+        else:
+            unidad_clave_deletreada = ".".join(unidad.clave)
 
         # Si no tiene ubicación mencionar la unidad
         texto = f"El Turno {unidad_clave_deletreada} {turno.numero}"
@@ -134,7 +137,10 @@ class VocearTurnos:
     def construir_mensaje_cubiculo(self, turno: Turno, unidad: Unidad) -> Mensaje:
         """Construye el mensaje para cada turno que son llamados a cubículos"""
 
-        unidad_clave_deletreada = ".".join(unidad.clave)
+        if unidad.pronunciacion:
+            unidad_clave_deletreada = unidad.pronunciacion
+        else:
+            unidad_clave_deletreada = ".".join(unidad.clave)
 
         # Si no tiene ubicación mencionar la unidad
         texto = f"El Turno {unidad_clave_deletreada} {turno.numero}"


### PR DESCRIPTION
### ✨ Mejoras

- Las unidades ahora incluyen un campo nuevo para indicar cómo pronunciarlo.

### ⚙️ Requerimiento

- Ejecutar SQL:
  - Añadir campo nuevo `pronunciacion` a la tabla `unidades`: `v1.3.0-01-add-campo-unidades.sql`.
