### PR TITLE
Fix entrega turnos unidad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ El formato se basa en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/
 ### ✏️ Cambios
 
 - Se cambio el estado del turno: `PASE A VENTANILLA` a `PASE A UBICACION`.
+- La pronunciación de la palabra 'Turno' no se oía bien, así que optamos por decir 'turrno'.
 
 ### 🐞 Arreglado
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ El formato se basa en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/
 
 ### ✨ Mejoras
 
+- La entrega de turnos por unidad también incluye los turnos en los nuevos estados.
 - Las unidades ahora incluyen un campo nuevo para indicar cómo pronunciarlo.
 - Nuevo estado de turno añadido: `ATENDIENDO EN CUBICULO`.
 - Añade vocear cuando el estado del turno es pasar a un cubículo. "PASE A VENTANILLA", "ATENDIENDO EN CUBICULO".

--- a/tauro/blueprints/api_oauth2_v1/endpoints/consultar_turnos_unidad.py
+++ b/tauro/blueprints/api_oauth2_v1/endpoints/consultar_turnos_unidad.py
@@ -37,18 +37,24 @@ class ConsultarTurnosUnidad(Resource):
 
         # Consultar los turnos...
         # - Filtrar por unidad,
-        # - Filtrar por los estados EN ESPERA y PASE A VENTANILLA,
+        # - Filtrar por los estados EN ESPERA o PASE A VENTANILLA o ATENDIENDO,
         # - Filtrar por el estatus A (activo),
         # - Y ordenar por el nombre de tipo de turno ATENCIÓN URGENTE, CON CITA, NORMAL y luego por el número del turno
         turnos = (
             Turno.query.join(TurnoEstado)
             .join(TurnoTipo)
             .filter(Turno.unidad_id == unidad.id)
-            .filter(TurnoEstado.nombre != "COMPLETADO", TurnoEstado.nombre != "CANCELADO")
+            .filter(
+                or_(
+                    TurnoEstado.nombre == "EN ESPERA",
+                    TurnoEstado.nombre == "PASE A VENTANILLA",
+                    TurnoEstado.nombre == "ATENDIENDO",
+                )
+            )
             .filter(Turno.estatus == "A")
             .order_by(
-                # 1. Prioridad por estado: PASE A VENTANILLA primero (valor 0), el resto después (valor 1)
-                case((TurnoEstado.nombre == "PASE A VENTANILLA", 0), else_=1),
+                # 1. Prioridad por estado: EN ESPERA primero (valor 0), el resto después (valor 1)
+                case((TurnoEstado.nombre == "EN ESPERA", 0), else_=1),
                 # 2. Dentro de cada grupo, ordenar por número de turno
                 Turno.numero,
             )
@@ -67,12 +73,17 @@ class ConsultarTurnosUnidad(Resource):
                 ),
             ).model_dump()
 
-        # Consultar Último turno en estado 'PASE A VENTANILLA'
+        # Consultar Último turno en estado 'ATENDIENDO' o 'ATENDIENDO EN CUBÍCULO'
         ultimo_turno_atendiendo = (
             Turno.query.join(TurnoEstado)
             .join(TurnoTipo)
             .filter(Turno.unidad_id == unidad.id)
-            .filter(or_(TurnoEstado.nombre == "PASE A VENTANILLA", TurnoEstado.nombre == "ATENDIENDO EN CUBICULO"))
+            .filter(
+                or_(
+                    TurnoEstado.nombre == "ATENDIENDO",
+                    TurnoEstado.nombre == "ATENDIENDO EN CUBICULO",
+                )
+            )
             .filter(Turno.estatus == "A")
             .order_by(TurnoTipo.nivel, Turno.numero)
             .first()

--- a/tauro/services/vocear_turnos.py
+++ b/tauro/services/vocear_turnos.py
@@ -120,7 +120,7 @@ class VocearTurnos:
             unidad_clave_deletreada = ".".join(unidad.clave)
 
         # Si no tiene ubicación mencionar la unidad
-        texto = f"El Turno {unidad_clave_deletreada} {turno.numero}"
+        texto = f"El Turrno {unidad_clave_deletreada} {turno.numero}"
 
         if turno.ubicacion.nombre == "NO DEFINIDO":
             texto = f" {texto} pase a {unidad.nombre}"
@@ -143,7 +143,7 @@ class VocearTurnos:
             unidad_clave_deletreada = ".".join(unidad.clave)
 
         # Si no tiene ubicación mencionar la unidad
-        texto = f"El Turno {unidad_clave_deletreada} {turno.numero}"
+        texto = f"El Turrno {unidad_clave_deletreada} {turno.numero}"
 
         if turno.numero_cubiculo:
             texto = f" {texto} pase al cubículo número {turno.numero_cubiculo}"


### PR DESCRIPTION
### ✨ Mejoras

- La entrega de turnos por unidad también incluye los turnos en los nuevos estados.

### ✏️ Cambios

- La pronunciación de la palabra 'Turno' no se oía bien, así que optamos por decir 'turrno'.